### PR TITLE
DEV: When click on categories go directly to their edit page

### DIFF
--- a/assets/javascripts/discourse/initializers/just-chat.js.es6
+++ b/assets/javascripts/discourse/initializers/just-chat.js.es6
@@ -79,6 +79,16 @@ export default {
             sidebarState.setPanel("chat");
           }
         }
+
+        // Force chat sidebar on category edit pages
+        if (window.location.pathname.match(/^\/c\/[^\/]+\/edit/) || window.location.pathname.match(/^\/c\/[^\/]+\/[^\/]+\/edit/)) {
+          const sidebarState =
+            api.container.lookup("service:sidebar-state") ||
+            api.container.lookup("service:sidebarState");
+          if (sidebarState && typeof sidebarState.setPanel === "function") {
+            sidebarState.setPanel("chat");
+          }
+        }
       });
 
       // Redirect all common list/user activity routes to /chat
@@ -104,6 +114,81 @@ export default {
           }
         });
       });
+
+      // Intercept category link clicks
+      api.onPageChange(() => {
+        // Handle category list links
+        document.querySelectorAll('.category-title-link').forEach(link => {
+          link.addEventListener('click', (e) => {
+            e.preventDefault();
+            const href = link.getAttribute('href');
+            if (href) {
+              const router = api.container.lookup("router:main");
+              // Extract the category path from the href, ignoring IDs
+              const match = href.match(/\/c\/([^\/]+(?:\/[^\/]+)?)(?:\/\d+)?$/);
+              if (match) {
+                // Remove any trailing ID from the category path
+                const categoryPath = match[1].replace(/\/\d+$/, '');
+                // Check if it's a subcategory
+                const parts = categoryPath.split('/');
+                if (parts.length > 1) {
+                  // It's a subcategory, use original parent category
+                  const targetUrl = `/c/${parts[0]}/${parts[1]}/edit/`;
+                  const sidebarState = api.container.lookup("service:sidebar-state") || api.container.lookup("service:sidebarState");
+                  if (sidebarState && typeof sidebarState.setPanel === "function") {
+                    sidebarState.setPanel("chat");
+                  }
+                  router.replaceWith(targetUrl);
+                } else {
+                  // It's a parent category
+                  const targetUrl = `/c/${categoryPath}/edit/`;
+                  const sidebarState = api.container.lookup("service:sidebar-state") || api.container.lookup("service:sidebarState");
+                  if (sidebarState && typeof sidebarState.setPanel === "function") {
+                    sidebarState.setPanel("chat");
+                  }
+                  router.replaceWith(targetUrl);
+                }
+              }
+            }
+          });
+        });
+
+        // Handle chat interface category links
+        document.querySelectorAll('.badge-category__wrapper').forEach(link => {
+          link.addEventListener('click', (e) => {
+            e.preventDefault();
+            const href = link.getAttribute('href');
+            if (href) {
+              const router = api.container.lookup("router:main");
+              // Extract the category path from the href, ignoring IDs
+              const match = href.match(/\/c\/([^\/]+(?:\/[^\/]+)?)(?:\/\d+)?$/);
+              if (match) {
+                // Remove any trailing ID from the category path
+                const categoryPath = match[1].replace(/\/\d+$/, '');
+                // Check if it's a subcategory
+                const parts = categoryPath.split('/');
+                if (parts.length > 1) {
+                  // It's a subcategory, use original parent category
+                  const targetUrl = `/c/${parts[0]}/${parts[1]}/edit/`;
+                  const sidebarState = api.container.lookup("service:sidebar-state") || api.container.lookup("service:sidebarState");
+                  if (sidebarState && typeof sidebarState.setPanel === "function") {
+                    sidebarState.setPanel("chat");
+                  }
+                  router.replaceWith(targetUrl);
+                } else {
+                  // It's a parent category
+                  const targetUrl = `/c/${categoryPath}/edit/`;
+                  const sidebarState = api.container.lookup("service:sidebar-state") || api.container.lookup("service:sidebarState");
+                  if (sidebarState && typeof sidebarState.setPanel === "function") {
+                    sidebarState.setPanel("chat");
+                  }
+                  router.replaceWith(targetUrl);
+                }
+              }
+            }
+          });
+        });
+      });
     });
-  },
+  }
 };

--- a/assets/javascripts/discourse/initializers/just-chat.js.es6
+++ b/assets/javascripts/discourse/initializers/just-chat.js.es6
@@ -14,10 +14,10 @@ export default {
       api.modifyClass("route:discovery", {
         beforeModel(transition) {
           if (
-            window.location.pathname === "/" &&
+            transition.targetName === "discovery.index" &&
             (!transition.from || transition.from === null)
           ) {
-            const router = getOwner(this).lookup("router:main");
+            const router = api.container.lookup("service:router");
             router.replaceWith("/chat");
           } else if (this._super) {
             return this._super(...arguments);
@@ -27,12 +27,8 @@ export default {
 
       function redirectToChatAndSidebar(router) {
         router.replaceWith("/chat");
-        const sidebarState =
-          api.container.lookup("service:sidebar-state") ||
-          api.container.lookup("service:sidebarState");
-        if (sidebarState && typeof sidebarState.setPanel === "function") {
-          sidebarState.setPanel("chat");
-        }
+        const sidebarState = api.container.lookup("service:sidebar-state");
+        sidebarState?.setPanel("chat");
       }
 
       // Block user drafts route in Ember
@@ -51,43 +47,32 @@ export default {
 
       // Force chat sidebar on preferences/account route
       api.onPageChange(() => {
-        if (window.location.pathname.match(/^\/u\/(.+?)\/preferences\/account/)) {
-          const sidebarState =
-            api.container.lookup("service:sidebar-state") ||
-            api.container.lookup("service:sidebarState");
-          if (sidebarState && typeof sidebarState.setPanel === "function") {
-            sidebarState.setPanel("chat");
-          }
+        const router = api.container.lookup("service:router");
+        if (router.currentRouteName === "user.preferences.account") {
+          const sidebarState = api.container.lookup("service:sidebar-state");
+          sidebarState?.setPanel("chat");
         }
       });
 
       // Redirect /categories to /chat for non-admins
       api.onPageChange(() => {
+        const router = api.container.lookup("service:router");
         if (
-          window.location.pathname === "/categories" &&
+          router.currentRouteName === "discovery.categories" &&
           !api.getCurrentUser()?.admin
         ) {
-          const router = api.container.lookup("router:main");
           router.replaceWith("/chat");
         }
         // Always force chat sidebar on /categories
-        if (window.location.pathname === "/categories") {
-          const sidebarState =
-            api.container.lookup("service:sidebar-state") ||
-            api.container.lookup("service:sidebarState");
-          if (sidebarState && typeof sidebarState.setPanel === "function") {
-            sidebarState.setPanel("chat");
-          }
+        if (router.currentRouteName === "discovery.categories") {
+          const sidebarState = api.container.lookup("service:sidebar-state");
+          sidebarState?.setPanel("chat");
         }
 
         // Force chat sidebar on category edit pages
-        if (window.location.pathname.match(/^\/c\/[^\/]+\/edit/) || window.location.pathname.match(/^\/c\/[^\/]+\/[^\/]+\/edit/)) {
-          const sidebarState =
-            api.container.lookup("service:sidebar-state") ||
-            api.container.lookup("service:sidebarState");
-          if (sidebarState && typeof sidebarState.setPanel === "function") {
-            sidebarState.setPanel("chat");
-          }
+        if (router.currentRouteName === "editCategory.tabs") {
+          const sidebarState = api.container.lookup("service:sidebar-state");
+          sidebarState?.setPanel("chat");
         }
       });
 
@@ -103,10 +88,10 @@ export default {
         api.modifyClass(`route:discovery/${filter}`, {
           beforeModel(transition) {
             if (
-              window.location.pathname === `/${filter}` &&
+              transition.targetName === `discovery.${filter}` &&
               (!transition.from || transition.from === null)
             ) {
-              const router = getOwner(this).lookup("router:main");
+              const router = api.container.lookup("service:router");
               router.replaceWith("/chat");
             } else if (this._super) {
               return this._super(...arguments);
@@ -123,7 +108,7 @@ export default {
             e.preventDefault();
             const href = link.getAttribute('href');
             if (href) {
-              const router = api.container.lookup("router:main");
+              const router = api.container.lookup("service:router");
               // Extract the category path from the href, ignoring IDs
               const match = href.match(/\/c\/([^\/]+(?:\/[^\/]+)?)(?:\/\d+)?$/);
               if (match) {
@@ -134,7 +119,7 @@ export default {
                 if (parts.length > 1) {
                   // It's a subcategory, use original parent category
                   const targetUrl = `/c/${parts[0]}/${parts[1]}/edit/`;
-                  const sidebarState = api.container.lookup("service:sidebar-state") || api.container.lookup("service:sidebarState");
+                  const sidebarState = api.container.lookup("service:sidebar-state");
                   if (sidebarState && typeof sidebarState.setPanel === "function") {
                     sidebarState.setPanel("chat");
                   }
@@ -142,7 +127,7 @@ export default {
                 } else {
                   // It's a parent category
                   const targetUrl = `/c/${categoryPath}/edit/`;
-                  const sidebarState = api.container.lookup("service:sidebar-state") || api.container.lookup("service:sidebarState");
+                  const sidebarState = api.container.lookup("service:sidebar-state");
                   if (sidebarState && typeof sidebarState.setPanel === "function") {
                     sidebarState.setPanel("chat");
                   }
@@ -159,7 +144,7 @@ export default {
             e.preventDefault();
             const href = link.getAttribute('href');
             if (href) {
-              const router = api.container.lookup("router:main");
+              const router = api.container.lookup("service:router");
               // Extract the category path from the href, ignoring IDs
               const match = href.match(/\/c\/([^\/]+(?:\/[^\/]+)?)(?:\/\d+)?$/);
               if (match) {
@@ -170,7 +155,7 @@ export default {
                 if (parts.length > 1) {
                   // It's a subcategory, use original parent category
                   const targetUrl = `/c/${parts[0]}/${parts[1]}/edit/`;
-                  const sidebarState = api.container.lookup("service:sidebar-state") || api.container.lookup("service:sidebarState");
+                  const sidebarState = api.container.lookup("service:sidebar-state");
                   if (sidebarState && typeof sidebarState.setPanel === "function") {
                     sidebarState.setPanel("chat");
                   }
@@ -178,7 +163,7 @@ export default {
                 } else {
                   // It's a parent category
                   const targetUrl = `/c/${categoryPath}/edit/`;
-                  const sidebarState = api.container.lookup("service:sidebar-state") || api.container.lookup("service:sidebarState");
+                  const sidebarState = api.container.lookup("service:sidebar-state");
                   if (sidebarState && typeof sidebarState.setPanel === "function") {
                     sidebarState.setPanel("chat");
                   }


### PR DESCRIPTION
Chat still relies on categories for permissions, but we don't want to
enter categories where it shows a list of topics. Instead when a
category is clicked on go directly to the category edit page.

This way we get direct access through chat when editing a channel to
also edit the category permissions tied to that channel.
